### PR TITLE
fix(ios): call result in setFinishMode to resolve Flutter Future

### DIFF
--- a/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
+++ b/android/src/main/kotlin/com/simform/audio_waveforms/AudioPlayer.kt
@@ -184,26 +184,28 @@ class AudioPlayer(
 
     fun setFinishMode(result: MethodChannel.Result, releaseModeType: Int?) {
         try {
-            releaseModeType?.let {
-                when (releaseModeType) {
-                    0 -> {
-                        this.finishMode = FinishMode.Loop
-                    }
+            when (releaseModeType) {
+                0 -> {
+                    this.finishMode = FinishMode.Loop
+                }
 
-                    1 -> {
-                        this.finishMode = FinishMode.Pause
-                    }
+                1 -> {
+                    this.finishMode = FinishMode.Pause
+                }
 
-                    2 -> {
-                        this.finishMode = FinishMode.Stop
-                    }
+                2 -> {
+                    this.finishMode = FinishMode.Stop
+                }
 
-                    else -> {
-                        throw Exception("Invalid Finish mode")
-                    }
+                null -> {
+                    throw Exception("Release mode is null")
+                }
+
+                else -> {
+                    throw Exception("Invalid Finish mode")
                 }
             }
-
+            result.success(null)
         } catch (e: Exception) {
             result.error(Constants.LOG_TAG, "Can not set the release mode", e.toString())
         }

--- a/ios/Classes/AudioPlayer.swift
+++ b/ios/Classes/AudioPlayer.swift
@@ -147,6 +147,7 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
         }else{
             self.finishMode = FinishMode.stop
         }
+        result(nil)
     }
 
     func startListening() {


### PR DESCRIPTION
Awaiting this method on Flutter side would hang due to missing result call.